### PR TITLE
Disallow use of undefined

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -47,6 +47,8 @@ module.exports = {
     'no-shadow-restricted-names': 2,
     'no-spaced-func': 2,
     'no-trailing-spaces': 2,
+    'no-undef-init': 2,
+    'no-undefined': 2,
     'no-unused-expressions': 2,
     'no-unused-vars': [2, { 'vars': 'all', 'args': 'after-used' }],
     'no-use-before-define': 0,


### PR DESCRIPTION
I want to add these two rules:
- http://eslint.org/docs/rules/no-undef-init
- http://eslint.org/docs/rules/no-undefined

Basically, I don't want to see `undefined` anywhere in our source 🙈  Use `null` or just put nothing.
