### PR TITLE
Enforce function declaration instead of function expression

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -14,6 +14,7 @@ module.exports = {
     'dot-notation': [2, { 'allowKeywords': true }],
     'eol-last': 2,
     'eqeqeq': 2,
+    'func-style': [2, 'declaration'],
     'guard-for-in': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
     'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],


### PR DESCRIPTION
Adding the rule `'func-style': [2, 'declaration']`
http://eslint.org/docs/rules/func-style#declaration

I prefer `function something() {}` over `const something = function() {}` because of the hoisting. Code that you can move easily and that doesn't depend on a specific execution order is usually good code ☝️ _Hoisting is a feature._ 