### PR TITLE
Enforce enforce one true brace style

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -6,6 +6,7 @@ module.exports = {
   rules: {
     'accessor-pairs': 0,
     'block-scoped-var': 2,
+    'brace-style': 2,
     'camelcase': 2,
     'comma-spacing': 2,
     'complexity': [0, 11],


### PR DESCRIPTION
http://eslint.org/docs/rules/brace-style

Opting for the default `1tbs` because it is the most concise style.