### PR TITLE
Disallow spaces inside of parentheses

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -71,6 +71,7 @@ module.exports = {
     'semi-spacing': [2, { 'before': false, 'after': true }],
     'space-before-blocks': ['error', 'always'],
     'space-before-function-paren': [2, 'never'],
+    'space-in-parens': ['error', 'never'],
     'space-infix-ops': 2,
     'space-unary-ops': [2, { 'words': true, 'nonwords': false }],
     'spaced-comment': [2, 'always'],


### PR DESCRIPTION
http://eslint.org/docs/rules/space-in-parens

Not a fundamental change since we have never added spaces except in a few places by mistake.