### PR TITLE
Allow double quotes to avoid escaping single quotes

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -67,7 +67,7 @@ module.exports = {
     'object-curly-spacing': [2, 'always'],
     'one-var': [2, { 'var': 'always', 'let': 'never', 'const': 'never' }],
     'prefer-template': 2,
-    'quotes': [2, 'single'],
+    'quotes': [2, 'single', { 'avoidEscape': true }],
     'semi': 2,
     'semi-spacing': [2, { 'before': false, 'after': true }],
     'space-before-blocks': ['error', 'always'],


### PR DESCRIPTION
https://eslint.org/docs/rules/quotes

Relaxing the rule for `quotes` to avoid escaping characters:
```js
'It\'s bad' // Hard to read
"It's better" // Easy to read
```