### PR TITLE
Allow space after 'async'

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -71,7 +71,7 @@ module.exports = {
     'semi': 2,
     'semi-spacing': [2, { 'before': false, 'after': true }],
     'space-before-blocks': ['error', 'always'],
-    'space-before-function-paren': [2, 'never'],
+    'space-before-function-paren': [2, 'never', { 'asyncArrow': 'always' }],
     'space-in-parens': ['error', 'never'],
     'space-infix-ops': 2,
     'space-unary-ops': [2, { 'words': true, 'nonwords': false }],


### PR DESCRIPTION
So we write:
```js
async () => a + b
```
instead of :
```js
async() => a + b
```

🙈 https://github.com/bandlab/eslint-config-bandlab/commit/5bbb8f5ecdccf7069be8a2a823925b72bdfa7eb8