### PR TITLE
Warn for variables used inside typeof check

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -55,6 +55,7 @@ module.exports = {
     'no-shadow': [0, { 'hoist': 'all' }],
     'no-shadow-restricted-names': 2,
     'no-trailing-spaces': 2,
+    'no-undef': [2, { 'typeof': true }],
     'no-undef-init': 2,
     'no-undefined': 2,
     'no-unused-expressions': 2,


### PR DESCRIPTION
Enabling the option `typeof` (https://eslint.org/docs/rules/no-undef) so

```js
if (typeof neverDefinedVariable === "string") { }
```

would be detected as an error.
 
_Just spent 5 minutes wondering why my checks weren't working as expected, it was a typo_ 😑 