### PR TITLE
Relax camelcase rule in case of properties

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -7,7 +7,7 @@ module.exports = {
     'accessor-pairs': 0,
     'block-scoped-var': 2,
     'brace-style': 2,
-    'camelcase': 2,
+    'camelcase': [2, { 'properties': 'never' }],
     'comma-spacing': 2,
     'complexity': [0, 11],
     'consistent-return': 0,


### PR DESCRIPTION
We have too many libs/API using "snake_case" conventions (https://github.com/bandlab/bandlab-web/pull/6193). It makes sense to remove this check.