### PR TITLE
Enforce consistency for quotes around property name

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -69,6 +69,7 @@ module.exports = {
     'one-var': [2, { 'var': 'always', 'let': 'never', 'const': 'never' }],
     'prefer-template': 2,
     'quotes': [2, 'single', { 'avoidEscape': true }],
+    'quote-props': [2, 'consistent-as-needed'],
     'semi': 2,
     'semi-spacing': [2, { 'before': false, 'after': true }],
     'space-before-blocks': ['error', 'always'],


### PR DESCRIPTION
https://eslint.org/docs/rules/quote-props

The inconsistency is bothering me a bit and with more devs in the team now, I prefer to set a rule to enforce it. Applied to `bandlab-web`: https://github.com/bandlab/bandlab-web/pull/8149