### PR TITLE
Enforce 'node:' protocol for built-in module

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -97,6 +97,7 @@ module.exports = {
     'unicorn/no-new-buffer': 'error',
     'unicorn/no-hex-escape': 'error',
     'unicorn/custom-error-definition': 'error',
+    'unicorn/prefer-node-protocol': 'error',
     'unicorn/prefer-type-error': 'error'
   }
 };


### PR DESCRIPTION
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md

> What are the benefits of using node: module specifiers?
> 
> It’s immediately clear that a built-in Node.js module is imported. Given how many of them there now are, that’s useful information.
> There is no risk of a module in node_modules overriding the built-in module.
> This is especially important whenever Node.js adds a new built-in module.
>
> https://2ality.com/2021/12/node-protocol-imports.html