### PR TITLE
Enforce empty line between function declarations

### DIFF
--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -67,6 +67,9 @@ module.exports = {
     'no-with': 2,
     'object-curly-spacing': [2, 'always'],
     'one-var': [2, { 'var': 'always', 'let': 'never', 'const': 'never' }],
+    'padding-line-between-statements': [2,
+      { "blankLine": "always", "prev": "function", "next": "function" }
+    ],
     'prefer-const': [2, { 'destructuring': 'all' }],
     'prefer-template': 2,
     'quotes': [2, 'single', { 'avoidEscape': true }],


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/padding-line-between-statements