### PR TITLE
Migrate to eslint-plugin-jsdoc

### DIFF
--- a/packages/eslint-config-bandlab-base/package.json
+++ b/packages/eslint-config-bandlab-base/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/bandlab/eslint-config-bandlab",
   "peerDependencies": {
     "eslint": ">=6.0.0",
+    "eslint-plugin-jsdoc": ">=46.8.2",
     "eslint-plugin-unicorn": ">=10.0.0"
   }
 }

--- a/packages/eslint-config-bandlab-base/rules/base.js
+++ b/packages/eslint-config-bandlab-base/rules/base.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: 'eslint:recommended',
   plugins: [
+    'jsdoc',
     'unicorn'
   ],
   rules: {
@@ -21,6 +22,15 @@ module.exports = {
     'func-style': [2, 'declaration'],
     'guard-for-in': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
+    'jsdoc/check-access': 2,
+    'jsdoc/check-alignment': 2,
+    'jsdoc/check-indentation': 2,
+    'jsdoc/check-line-alignment': 2,
+    'jsdoc/check-param-names': 2,
+    'jsdoc/check-property-names': 2,
+    'jsdoc/check-tag-names': [2, { 'definedTags': ['element', 'ngdoc', 'restrict'] }],
+    'jsdoc/check-types': 2,
+    'jsdoc/check-values': 2,
     'key-spacing': [2, { 'beforeColon': false, 'afterColon': true }],
     'keyword-spacing': [2, { 'before': true, 'after': true }],
     'linebreak-style': [2, 'unix'],
@@ -86,11 +96,6 @@ module.exports = {
     'strict': [0],
     'template-curly-spacing': [2, 'never'],
     'yoda': 2,
-    'valid-jsdoc': ['error', {
-      'prefer': { 'arg': 'param', 'argument': 'param', 'class': 'constructor', 'return': 'returns', 'virtual': 'abstract' },
-      'preferType': { 'boolean': 'Boolean', 'number': 'Number', 'object': 'Object', 'string': 'String' },
-      'requireReturn': false
-    }],
     'unicorn/catch-error-name': ['error', { 'name': 'err' }],
     'unicorn/no-abusive-eslint-disable': 'error',
     'unicorn/no-process-exit': 'error',
@@ -103,5 +108,11 @@ module.exports = {
     'unicorn/custom-error-definition': 'error',
     'unicorn/prefer-node-protocol': 'error',
     'unicorn/prefer-type-error': 'error'
+  },
+  settings: {
+    jsdoc: {
+      preferredTypes: { 'boolean': 'Boolean', 'number': 'Number', 'object': 'Object', 'string': 'String' },
+      tagNamePreference :{ 'class': 'constructor', 'return': 'returns' }
+    }
   }
 };


### PR DESCRIPTION
https://eslint.org/blog/2018/11/jsdoc-end-of-life/
https://github.com/gajus/eslint-plugin-jsdoc

Configured all `check-*` rules except:
- https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-examples.md
- https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-syntax.md (we currently use Closure syntax, not sure yet if it will play well with TypeScript)